### PR TITLE
Reset display to all data when clicking "CLEAR" and handle ⓧ click

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 		<script type="text/javascript">
 		  document.addEventListener('DOMContentLoaded', function() {
 	      var URL = "0AvFUWxii39gXdGxhcjhzYzlBX2pyVFZZU2VjZ3BHZ3c"
-	      Tabletop.init( { key: URL, callback: drawToolBox, simpleSheet: true } )
+	      Tabletop.init( { key: URL, callback: initialize, simpleSheet: true } )
 	    })
 		</script>
 	</body>

--- a/js/site.js
+++ b/js/site.js
@@ -23,7 +23,7 @@ $(document).on( 'click', '.clear', function(e) {
     .html('Show Available')
 })
 
-$(document).on('keyup', '#toolSearch', function(e) {
+$(document).on('keyup search', '#toolSearch', function(e) {
   var text = $(e.target).val().trim().toLowerCase()
 
   if (text === '') return clearSearch(e)

--- a/js/site.js
+++ b/js/site.js
@@ -1,3 +1,13 @@
+var gData;
+/*
+    Draw the toolbox with an array of spreadsheet data
+    and cache the data in a global variable.
+*/
+function initialize(data) {
+    gData = data
+    drawToolBox(data)
+}
+
 function drawToolBox(data) {
   var tools = ich.tools({
     'rows': data


### PR DESCRIPTION
This creates a global variable (`gData`) that is set in the `Tabletop.init` callback, and holds the returned rows from `Tabletop.init`.  The defines `gData` in `clearSearch`.

According to [this StackOverflow answer](http://stackoverflow.com/questions/2977023/how-do-you-detect-the-clearing-of-a-search-html5-input), clicking on the ⓧ  issues a `search` event from the input.

I just added the `search` event to the `keyup` handling for the event. Confirmed by debugging the block that this isn't double called. `search` is only triggered when the ⓧ  is clicked, not on every keypress. `keyup` works normally.

Closes #6