### PR TITLE
Use CSS classes to hide unavailable items

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -40,6 +40,9 @@ input:not([type=submit]):not([type=file]):not([type=checkbox]) {margin: 19px 4px
 #tools {-webkit-column-count:3; -webkit-column-gap : 16px; -webkit-column-width: 250px; -moz-column-count:3;
   -moz-column-gap : 16px; -moz-column-width: 250px;}
 
+#tools.show-available .not-available { display: none; }
+#tools .filtered { display: none; }
+
 .tool-box { background: #E0E0DF; color: #5A5A5A; padding: 12px; margin-bottom: 16px; box-sizing: border-box;
    -mox-box-sizing:border-box; -webkit-column-break-inside:avoid; -moz-column-break-inside:avoid;
    display: table; width: 100%;}

--- a/js/site.js
+++ b/js/site.js
@@ -19,18 +19,12 @@ $(document).on( 'click', '#showAvailable', toggleAvailable)
 
 $(document).on( 'click', '.clear', function(e) {
   clearSearch(e)
-  $('#showAvailable').removeClass('button-pressed')
-    .html('Show Available')
+  toggleAvailable(false)
 })
 
 $(document).on('keyup search', '#toolSearch', function(e) {
   var text = $(e.target).val().trim().toLowerCase()
-
   if (text === '') return clearSearch(e)
-  if ($('.button-pressed').length === 1) {
-    console.log('Hide unavailable')
-    $('.tool-box').filter('.not-available').hide()
-  }
   filterTools(text)
 })
 
@@ -46,22 +40,25 @@ $(document).on( 'click', '.tool-box-tool', function(e) {
   }
 })
 
-function toggleAvailable() {
-  if ($('.button-pressed').length === 0) {
-    console.log('off')
-    $('#showAvailable').addClass('button-pressed')
-      .html('Show All')
-    $('.not-available').hide()
-  } else {
-    console.log('on')
-    $('#showAvailable')
-      .html('Show Available').removeClass('button-pressed')
-    if ($('#toolSearch').val() != '') {
-      console.log("search not empty")
-      return filterTools($('#toolSearch').val())
+/*
+    Toggle whether unavailable items are displayed or not
+
+    [state] - optionally specify the desired state, either true or false. If
+    not defined, it will just toggle.
+*/
+function toggleAvailable(state) {
+    // Since #showAvailable and #tools both start out without the class, they
+    // will remain in sync
+    let button = $('#showAvailable').toggleClass('button-pressed', state)
+    // CSS in site.css hides tools that are '.show-available .not-available'
+    $('#tools').toggleClass('show-available', state)
+
+    // Update the button text
+    if (button.hasClass('button-pressed')) {
+        button.html("Show All")
+    } else {
+        button.html("Show Available")
     }
-    $('.not-available').show()
-  }
 }
 
 function clearSearch(e) {
@@ -74,7 +71,7 @@ function filterTools(text) {
   $('.tool-box-tool').each(function() {
   var tool = $(this).html().toLowerCase()
   if (tool.match(text)) {
-    $(this).parent().show()
-  } else $(this).parent().hide()
+    $(this).parent().removeClass('filtered')
+} else $(this).parent().addClass('filtered')
   })
 }


### PR DESCRIPTION
This replaces some of the toggling with a CSS class on the tools container, that when set, along with the `not-available` class on each item, set's their display property to `none`. When the button is pressed, this just toggles the container class as well.

This also updates the filtering logic to work with __SHOW AVAILABLE__. jQuery's `show` method adds inline style `display: block;`, overriding any previous logic. This  uses a class, `filtered`, instead of jQuery `show`/`hide`

A lot of jQuery code re-running filters, etc. get to be deleted, fixing #8! I'm not 100% sure splitting the display logic between the CSS/JS is a great idea though.